### PR TITLE
disable exec-shield on rhel/centos 7

### DIFF
--- a/integration/rhel7_centos7/serverspec/localhost/amcs_secc_os_linux_spec.rb
+++ b/integration/rhel7_centos7/serverspec/localhost/amcs_secc_os_linux_spec.rb
@@ -115,9 +115,9 @@ require 'spec_helper'
     end
 
     # req. 16 / 3_21 Unix
-    # kernel > 3.0 does not have this parameter
+    # rhel7 should not have this value
     context linux_kernel_parameter('kernel.exec-shield') do
-      its(:value) { should_not eq 0 }
+      its(:value) { should_not exist }
     end
     context linux_kernel_parameter('kernel.randomize_va_space') do
       its(:value) { should eq 2 }

--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -380,7 +380,7 @@ class secc_os_linux::kernel (
     notify => [Exec['sysctl_load'], Exec['rebuild_initramfs']],
   }
 
-  if ( $::kernelmajversion < '3.0' ) {
+  if Integer.new($::operatingsystemmajrelease) < 7 {
     file_line { 'kernel_exec_shield' :
       ensure => present,
       path   => '/etc/sysctl.conf',
@@ -388,7 +388,6 @@ class secc_os_linux::kernel (
       match  => 'kernel.exec-shield.*',
       notify => [Exec['sysctl_load'], Exec['rebuild_initramfs']],
     }
-
   }
 
   exec { 'sysctl_load':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "tsystemsmms-secc_os_linux",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "T-Systems Multimedia Solutions GmbH",
   "summary": "Dieses Modul bietet eine teilweise Abdeckung der SoC Anforderungen für OS unter Linux.",
   "license": "Apache-2.0",


### PR DESCRIPTION
on rhel/centos 7 machines exec-shield is no longer available.

see also: https://access.redhat.com/solutions/974563